### PR TITLE
Create modded_stripped_logs.json

### DIFF
--- a/src/main/resources/data/create/tags/items/modded_stripped_logs.json
+++ b/src/main/resources/data/create/tags/items/modded_stripped_logs.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "#natures_spirit:stripped_logs"
+  ]
+}


### PR DESCRIPTION
Add Nature's Spirit Stripped Logs to Create's "modded_stripped_logs" tag.
Fixes not being able to use Nature's Spirit stripped logs and stripped wood in constructing create casing blocks.