### PR TITLE
[Fixed] Couldn't load certain entries with the tag

### DIFF
--- a/src/main/resources/resourcepacks/arts_and_crafts_dat/data/arts_and_crafts/tags/worldgen/biome/soapstone_can_generate_in.json
+++ b/src/main/resources/resourcepacks/arts_and_crafts_dat/data/arts_and_crafts/tags/worldgen/biome/soapstone_can_generate_in.json
@@ -49,7 +49,6 @@
     "natures_spirit:wisteria_forest",
     "natures_spirit:wooded_drylands",
     "natures_spirit:woody_highlands",
-    "natures_spirit:xeric_plains",
-    "newworld:wooded_meadow"
+    "natures_spirit:xeric_plains"
   ]
 }


### PR DESCRIPTION
Couldn't load certain entries with the tag arts_and_crafts:soapstone_can_generate_in: newworld:wooded_meadow (from natures_spirit:arts_and_crafts_dat)