### PR TITLE
Fix missing stripped wood item tag

### DIFF
--- a/src/main/generated/data/natures_spirit/tags/item/stripped_wood.json
+++ b/src/main/generated/data/natures_spirit/tags/item/stripped_wood.json
@@ -1,0 +1,22 @@
+{
+  "values": [
+    "natures_spirit:stripped_mahogany_wood",
+    "natures_spirit:stripped_saxaul_wood",
+    "natures_spirit:stripped_redwood_wood",
+    "natures_spirit:stripped_aspen_wood",
+    "natures_spirit:stripped_fir_wood",
+    "natures_spirit:stripped_cypress_wood",
+    "natures_spirit:stripped_coconut_wood",
+    "natures_spirit:stripped_wisteria_wood",
+    "natures_spirit:stripped_willow_wood",
+    "natures_spirit:stripped_cedar_wood",
+    "natures_spirit:stripped_sugi_wood",
+    "natures_spirit:stripped_palo_verde_wood",
+    "natures_spirit:stripped_olive_wood",
+    "natures_spirit:stripped_joshua_bundle",
+    "natures_spirit:stripped_ghaf_wood",
+    "natures_spirit:stripped_maple_wood",
+    "natures_spirit:stripped_larch_wood",
+    "natures_spirit:stripped_alluaudia_bundle"
+  ]
+}

--- a/src/main/java/net/hibiscus/naturespirit/datagen/NSItemTagGenerator.java
+++ b/src/main/java/net/hibiscus/naturespirit/datagen/NSItemTagGenerator.java
@@ -54,6 +54,7 @@ public class NSItemTagGenerator extends FabricTagProvider.ItemTagProvider {
     copy(BlockTags.WOODEN_PRESSURE_PLATES, ItemTags.WOODEN_PRESSURE_PLATES);
     copy(BlockTags.SAPLINGS, ItemTags.SAPLINGS);
     copy(BlockTags.LOGS_THAT_BURN, ItemTags.LOGS_THAT_BURN);
+    copy(NSTags.Blocks.STRIPPED_WOOD, NSTags.Items.STRIPPED_WOOD);
     copy(BlockTags.LEAVES, ItemTags.LEAVES);
     copy(BlockTags.WOODEN_TRAPDOORS, ItemTags.WOODEN_TRAPDOORS);
     copy(BlockTags.STANDING_SIGNS, ItemTags.SIGNS);


### PR DESCRIPTION
Fixes #164.

Adds generation for the missing `natures_spirit:stripped_wood` item tag by copying the existing block tag into the matching item tag.

Verified with:
- `./gradlew.bat runDatagenClient`
- `./gradlew.bat processResources`

Note: `./gradlew.bat build` currently fails in the existing `jar` task due to `build.gradle` referencing unknown property `archivesBaseName`, which appears unrelated to this change.