### PR TITLE
Fix olive leaves generating detached

### DIFF
--- a/src/main/java/net/hibiscus/naturespirit/datagen/NSConfiguredFeatures.java
+++ b/src/main/java/net/hibiscus/naturespirit/datagen/NSConfiguredFeatures.java
@@ -493,7 +493,7 @@ public class NSConfiguredFeatures {
       register(context, OLIVE_TREE, Feature.TREE, new TreeFeatureConfig.Builder(BlockStateProvider.of(NSWoods.OLIVE.getLog()),
               new OliveTrunkPlacer(4, 1, 2, UniformIntProvider.create(4, 6), .85F, UniformIntProvider.create(4, 5), Registries.BLOCK.getOrCreateEntryList(BlockTags.MANGROVE_LOGS_CAN_GROW_THROUGH)),
               BlockStateProvider.of(NSWoods.OLIVE.getLeaves()),
-              new RandomSpreadFoliagePlacer(ConstantIntProvider.create(3), ConstantIntProvider.create(0), ConstantIntProvider.create(2), 60),
+              new BlobFoliagePlacer(ConstantIntProvider.create(3), ConstantIntProvider.create(0), 2),
               new TwoLayersFeatureSize(1, 0, 1, OptionalInt.of(5))
       ).ignoreVines().build());
 

--- a/src/main/java/net/hibiscus/naturespirit/datagen/NSConfiguredFeatures.java
+++ b/src/main/java/net/hibiscus/naturespirit/datagen/NSConfiguredFeatures.java
@@ -583,7 +583,7 @@ public class NSConfiguredFeatures {
       register(context, GHAF_TREE, Feature.TREE, new TreeFeatureConfig.Builder(BlockStateProvider.of(NSWoods.GHAF.getLog()),
               new GhafTrunkPlacer(4, 1, 2, UniformIntProvider.create(4, 6), .95F, UniformIntProvider.create(4, 6), Registries.BLOCK.getOrCreateEntryList(BlockTags.MANGROVE_LOGS_CAN_GROW_THROUGH)),
               BlockStateProvider.of(NSWoods.GHAF.getLeaves()),
-              new RandomSpreadFoliagePlacer(ConstantIntProvider.create(3), ConstantIntProvider.create(0), ConstantIntProvider.create(2), 60),
+              new BlobFoliagePlacer(ConstantIntProvider.create(3), ConstantIntProvider.create(0), 2),
               new TwoLayersFeatureSize(1, 0, 1, OptionalInt.of(3))
       ).ignoreVines().build());
 

--- a/src/main/resources/resourcepacks/modified_dark_forest/data/minecraft/worldgen/configured_feature/dark_oak.json
+++ b/src/main/resources/resourcepacks/modified_dark_forest/data/minecraft/worldgen/configured_feature/dark_oak.json
@@ -11,7 +11,7 @@
     "foliage_placer": {
       "type": "minecraft:dark_oak_foliage_placer",
       "offset": 0,
-      "radius": 1
+      "radius": 0
     },
     "foliage_provider": {
       "type": "minecraft:simple_state_provider",
@@ -36,8 +36,8 @@
     },
     "trunk_placer": {
       "type": "minecraft:dark_oak_trunk_placer",
-      "base_height": 7,
-      "height_rand_a": 4,
+      "base_height": 6,
+      "height_rand_a": 2,
       "height_rand_b": 1
     },
     "trunk_provider": {


### PR DESCRIPTION
Fixes #168.

Changes olive trees on the 1.20.1 branch to use `BlobFoliagePlacer` instead of `RandomSpreadFoliagePlacer`.

The previous random spread foliage could place isolated leaves around olive tree foliage nodes, causing some generated leaves to appear detached and later decay. Blob foliage keeps the generated canopy connected around the branch nodes.

Verified with:
- `./gradlew.bat compileJava`
- `./gradlew.bat processResources`
- `./gradlew.bat build`
